### PR TITLE
Coerce 'BeerSession.Active' to boolean

### DIFF
--- a/src/server/services/mysql_database.ts
+++ b/src/server/services/mysql_database.ts
@@ -46,7 +46,7 @@ export class MysqlDatabase implements Database {
 
     private mapBeerSession(result: any): BeerSession {
         let session: BeerSession = {
-            Active: result.Active,
+            Active: !!result.Active,
             SessionId: result.SessionId,
             NetVote: result.NetVote,
             UserVote: result.UserVote,


### PR DESCRIPTION
It is currently being serialized to JSON as an integer:
```
{
  "Active": 1,
  // etc 
}
```

Note: this does not affect the web client because it does not consume this field.